### PR TITLE
remove k8s.io/api/core/v1

### DIFF
--- a/pkg/apis/topology/v1alpha1/types.go
+++ b/pkg/apis/topology/v1alpha1/types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 


### PR DESCRIPTION
it has been included for ResourceList, there is more ResourceList here.

Signed-off-by: Alexey Perevalov <alexey.perevalov@huawei.com>